### PR TITLE
[ADDED] Link to OpenAPI specification project for Medium.

### DIFF
--- a/SDK.md
+++ b/SDK.md
@@ -15,3 +15,9 @@ These unofficial SDKs were produced by members of the open source community and 
 
 - [Medium SDK for PHP](https://github.com/jonathantorres/medium-sdk-php)
 - [Medium SDK for Haskell](https://github.com/timmytofu/medium-sdk-haskell)
+
+#### OpenAPI Specification (fka Swagger 2.0)
+This is unofficial [OpenAPI Specification](https://github.com/OAI/OpenAPI-Specification) for Medium. 
+- [Medium API Specification](https://github.com/amardeshbd/medium-api-specification)
+
+This specification can be used to [generate](https://github.com/swagger-api/swagger-codegen) client SDKs in different languages. 


### PR DESCRIPTION
_DISCLAIMER: I am the project owner for the Medium's OpenAPI Specification that is added in this PR_

**https://github.com/amardeshbd/medium-api-specification**

I've added link to github project that has the OpenAPI specification for Medium. The specification is translated from **official-api-doc** found in this project.

I believe, this open standard specification will be helpful for people who want to jumpstart their project in different language which has no official client SDK support. Currently [swagger-codegen ](https://github.com/swagger-api/swagger-codegen) supports following languages for client SDK

> android, aspnet5, async-scala, cwiki, csharp, cpprest, dart, flash, python-flask, go, groovy, java, jaxrs, jaxrs-cxf, jaxrs-resteasy, jaxrs-spec, inflector, javascript, javascript-closure-angular, jmeter, nancyfx, nodejs-server, objc, perl, php, python, qt5cpp, ruby, scala, scalatra, silex-PHP, sinatra, rails5, slim, spring, dynamic-html, html, html2, swagger, swagger-yaml, swift, tizen, typescript-angular2, typescript-angular, typescript-node, typescript-fetch, akka-scala, CsharpDotNet2, clojure, haskell, lumen, go-server

Let me know if the content of the wiki needs to be changed, or if this is in appropriate for this section.

Thanks in advance. 
