### PR TITLE
Add "notifyFollowers" to documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,7 @@ With the following fields:
 | canonicalUrl    | string       | optional   | The original home of this content, if it was originally published elsewhere.                         |
 | publishStatus   | enum         | optional   | The status of the post. Valid values are “public”, “draft”, or “unlisted”. The default is “public”.  |
 | license         | enum         | optional   | The license of the post. Valid values are “all-rights-reserved”, “cc-40-by”, “cc-40-by-sa”, “cc-40-by-nd”, “cc-40-by-nc”, “cc-40-by-nc-nd”, “cc-40-by-nc-sa”, “cc-40-zero”, “public-domain”. The default is “all-rights-reserved”. |
+| notifyFollowers | bool         | optional   | Whether to notifyFollowers that the user has published. |
 
 The response is a Post object within a data envelope. Example response:
 


### PR DESCRIPTION
Hello @benmedium, @julien51, @amyquispe, 

Please review the following commits I made in branch 'huckphin/add-notify-followers'.

624a1898989d7b2148d60923d5a0401bc7d341b5 (2016-09-19 17:39:38 -0700)
Add "notifyFollowers" to documentation.
Fixes https://github.com/Medium/medium-api-docs/issues/75

R=@benmedium
R=@julien51
R=@amyquispe